### PR TITLE
dateParse

### DIFF
--- a/server.js
+++ b/server.js
@@ -23,12 +23,18 @@ app.get("/api/hello", function (req, res) {
   res.json({greeting: 'hello API'});
 });
 
-app.get("/api/:inputDate", (req, res, next) => {
+app.get("/api/:inputDate?", (req, res, next) => {
   // unix epoch time needs to be int, not string
   if( !isNaN(req.params.inputDate) ) {
     req.params.inputDate = Number(req.params.inputDate)
   }
-  let formatedDate = new Date(req.params.inputDate)
+  // check if parameter is empy
+  if (req.params.inputDate) {
+    var formatedDate = new Date(req.params.inputDate)
+  } else {
+    var formatedDate = new Date()
+  }
+  // check date is valid
   if (formatedDate.toString() === "Invalid Date") {
     res.json( { error: "Invalid Date" } )
   } else {

--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ app.get("/api/hello", function (req, res) {
 });
 
 app.get("/api/:inputDate", (req, res, next) => {
-  let formatedDate = new Date(Date.parse(req.params.inputDate))
+  let formatedDate = new Date(req.params.inputDate)
   res.json({unix: formatedDate.getTime(), utc: formatedDate.toUTCString()})
 })
 

--- a/server.js
+++ b/server.js
@@ -24,8 +24,16 @@ app.get("/api/hello", function (req, res) {
 });
 
 app.get("/api/:inputDate", (req, res, next) => {
+  // unix epoch time needs to be int, not string
+  if( !isNaN(req.params.inputDate) ) {
+    req.params.inputDate = Number(req.params.inputDate)
+  }
   let formatedDate = new Date(req.params.inputDate)
-  res.json({unix: formatedDate.getTime(), utc: formatedDate.toUTCString()})
+  if (formatedDate.toString() === "Invalid Date") {
+    res.json( { error: "Invalid Date" } )
+  } else {
+    res.json({unix: formatedDate.getTime(), utc: formatedDate.toUTCString()})
+  }
 })
 
 // listen for requests :)

--- a/server.js
+++ b/server.js
@@ -23,13 +23,8 @@ app.get("/api/hello", function (req, res) {
   res.json({greeting: 'hello API'});
 });
 
-app.get("/api/:year-:month-:day", (req, res, next) => {
-  let formatedDate = new Date(Date.UTC(req.params.year, (req.params.month - 1), req.params.day))
-  res.json({unix: formatedDate.getTime(), utc: formatedDate.toUTCString()})
-})
-
 app.get("/api/:inputDate", (req, res, next) => {
-  let formatedDate = new Date(Number(req.params.inputDate))
+  let formatedDate = new Date(Date.parse(req.params.inputDate))
   res.json({unix: formatedDate.getTime(), utc: formatedDate.toUTCString()})
 })
 


### PR DESCRIPTION
- initial implementation breaks due to var type differences
- date.parse not necessary
- successfully parses date_string and invalid dates
- implemented check for empty parameter
